### PR TITLE
Add parameterized modules with config include

### DIFF
--- a/config.vh
+++ b/config.vh
@@ -1,0 +1,4 @@
+`define A_TO_B_WIDTH 8
+`define B_TO_A_WIDTH 16
+`define A_EXTRA_WIDTH 4
+`define B_EXTRA_WIDTH 12

--- a/moduleA.v
+++ b/moduleA.v
@@ -1,0 +1,14 @@
+`include "config.vh"
+
+module moduleA (
+    input  [IN_FROM_B_WIDTH-1:0] data_from_B,
+    input  [A_EXTRA_WIDTH_LP-1:0] a_extra_in,
+    output [TO_B_WIDTH-1:0] data_to_B,
+    output [A_EXTRA_WIDTH_LP-1:0] a_extra_out
+);
+
+    localparam IN_FROM_B_WIDTH = `B_TO_A_WIDTH;
+    localparam TO_B_WIDTH      = `A_TO_B_WIDTH;
+    localparam A_EXTRA_WIDTH_LP = `A_EXTRA_WIDTH;
+
+endmodule

--- a/moduleB.v
+++ b/moduleB.v
@@ -1,0 +1,14 @@
+`include "config.vh"
+
+module moduleB (
+    output [IN_TO_A_WIDTH-1:0] data_from_B,
+    input  [FROM_A_WIDTH-1:0] data_to_B,
+    input  [B_EXTRA_WIDTH_LP-1:0] b_extra_in,
+    output [B_EXTRA_WIDTH_LP-1:0] b_extra_out
+);
+
+    localparam IN_TO_A_WIDTH   = `B_TO_A_WIDTH;
+    localparam FROM_A_WIDTH    = `A_TO_B_WIDTH;
+    localparam B_EXTRA_WIDTH_LP = `B_EXTRA_WIDTH;
+
+endmodule


### PR DESCRIPTION
## Summary
- add `config.vh` to centralize macro definitions
- create `moduleA.v` and `moduleB.v` that include the config file
- define port widths via localparams using macros so that matching ports share widths

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_687f9ca03d84832083002edfa7a6b2c3