### PR TITLE
Refactor port declarations

### DIFF
--- a/moduleA.v
+++ b/moduleA.v
@@ -1,14 +1,19 @@
 `include "config.vh"
 
 module moduleA (
-    input  [IN_FROM_B_WIDTH-1:0] data_from_B,
-    input  [A_EXTRA_WIDTH_LP-1:0] a_extra_in,
-    output [TO_B_WIDTH-1:0] data_to_B,
-    output [A_EXTRA_WIDTH_LP-1:0] a_extra_out
+    data_from_B,
+    a_extra_in,
+    data_to_B,
+    a_extra_out
 );
 
     localparam IN_FROM_B_WIDTH = `B_TO_A_WIDTH;
     localparam TO_B_WIDTH      = `A_TO_B_WIDTH;
     localparam A_EXTRA_WIDTH_LP = `A_EXTRA_WIDTH;
+
+    input  [IN_FROM_B_WIDTH-1:0] data_from_B;
+    input  [A_EXTRA_WIDTH_LP-1:0] a_extra_in;
+    output [TO_B_WIDTH-1:0] data_to_B;
+    output [A_EXTRA_WIDTH_LP-1:0] a_extra_out;
 
 endmodule

--- a/moduleB.v
+++ b/moduleB.v
@@ -1,14 +1,19 @@
 `include "config.vh"
 
 module moduleB (
-    output [IN_TO_A_WIDTH-1:0] data_from_B,
-    input  [FROM_A_WIDTH-1:0] data_to_B,
-    input  [B_EXTRA_WIDTH_LP-1:0] b_extra_in,
-    output [B_EXTRA_WIDTH_LP-1:0] b_extra_out
+    data_from_B,
+    data_to_B,
+    b_extra_in,
+    b_extra_out
 );
 
     localparam IN_TO_A_WIDTH   = `B_TO_A_WIDTH;
     localparam FROM_A_WIDTH    = `A_TO_B_WIDTH;
     localparam B_EXTRA_WIDTH_LP = `B_EXTRA_WIDTH;
+
+    output [IN_TO_A_WIDTH-1:0] data_from_B;
+    input  [FROM_A_WIDTH-1:0] data_to_B;
+    input  [B_EXTRA_WIDTH_LP-1:0] b_extra_in;
+    output [B_EXTRA_WIDTH_LP-1:0] b_extra_out;
 
 endmodule


### PR DESCRIPTION
## Summary
- simplify module port syntax by separating width declarations

## Testing
- `iverilog -o /tmp/a.out moduleA.v moduleB.v && echo ok`

------
https://chatgpt.com/codex/tasks/task_e_687fa08907fc832097bb09ff483914b5