### PR TITLE
Align bitwidth macros with port names

### DIFF
--- a/config.vh
+++ b/config.vh
@@ -2,3 +2,11 @@
 `define B_TO_A_WIDTH 16
 `define A_EXTRA_WIDTH 4
 `define B_EXTRA_WIDTH 12
+
+// Per-port bitwidth macros derived from the common configuration above
+`define DATA_FROM_B_BITWIDTH `B_TO_A_WIDTH
+`define DATA_TO_B_BITWIDTH   `A_TO_B_WIDTH
+`define A_EXTRA_IN_BITWIDTH  `A_EXTRA_WIDTH
+`define A_EXTRA_OUT_BITWIDTH `A_EXTRA_WIDTH
+`define B_EXTRA_IN_BITWIDTH  `B_EXTRA_WIDTH
+`define B_EXTRA_OUT_BITWIDTH `B_EXTRA_WIDTH

--- a/moduleA.v
+++ b/moduleA.v
@@ -7,13 +7,15 @@ module moduleA (
     a_extra_out
 );
 
-    localparam IN_FROM_B_WIDTH = `B_TO_A_WIDTH;
-    localparam TO_B_WIDTH      = `A_TO_B_WIDTH;
-    localparam A_EXTRA_WIDTH_LP = `A_EXTRA_WIDTH;
+    // Port width localparams follow the convention PORTNAME_BITWIDTH
+    localparam DATA_FROM_B_BITWIDTH = `DATA_FROM_B_BITWIDTH;
+    localparam A_EXTRA_IN_BITWIDTH  = `A_EXTRA_IN_BITWIDTH;
+    localparam DATA_TO_B_BITWIDTH   = `DATA_TO_B_BITWIDTH;
+    localparam A_EXTRA_OUT_BITWIDTH = `A_EXTRA_OUT_BITWIDTH;
 
-    input  [IN_FROM_B_WIDTH-1:0] data_from_B;
-    input  [A_EXTRA_WIDTH_LP-1:0] a_extra_in;
-    output [TO_B_WIDTH-1:0] data_to_B;
-    output [A_EXTRA_WIDTH_LP-1:0] a_extra_out;
+    input  [DATA_FROM_B_BITWIDTH-1:0] data_from_B;
+    input  [A_EXTRA_IN_BITWIDTH-1:0]  a_extra_in;
+    output [DATA_TO_B_BITWIDTH-1:0]   data_to_B;
+    output [A_EXTRA_OUT_BITWIDTH-1:0] a_extra_out;
 
 endmodule

--- a/moduleB.v
+++ b/moduleB.v
@@ -7,13 +7,15 @@ module moduleB (
     b_extra_out
 );
 
-    localparam IN_TO_A_WIDTH   = `B_TO_A_WIDTH;
-    localparam FROM_A_WIDTH    = `A_TO_B_WIDTH;
-    localparam B_EXTRA_WIDTH_LP = `B_EXTRA_WIDTH;
+    // Port width localparams follow the convention PORTNAME_BITWIDTH
+    localparam DATA_FROM_B_BITWIDTH = `DATA_FROM_B_BITWIDTH;
+    localparam DATA_TO_B_BITWIDTH   = `DATA_TO_B_BITWIDTH;
+    localparam B_EXTRA_IN_BITWIDTH  = `B_EXTRA_IN_BITWIDTH;
+    localparam B_EXTRA_OUT_BITWIDTH = `B_EXTRA_OUT_BITWIDTH;
 
-    output [IN_TO_A_WIDTH-1:0] data_from_B;
-    input  [FROM_A_WIDTH-1:0] data_to_B;
-    input  [B_EXTRA_WIDTH_LP-1:0] b_extra_in;
-    output [B_EXTRA_WIDTH_LP-1:0] b_extra_out;
+    output [DATA_FROM_B_BITWIDTH-1:0] data_from_B;
+    input  [DATA_TO_B_BITWIDTH-1:0]   data_to_B;
+    input  [B_EXTRA_IN_BITWIDTH-1:0]  b_extra_in;
+    output [B_EXTRA_OUT_BITWIDTH-1:0] b_extra_out;
 
 endmodule


### PR DESCRIPTION
## Summary
- define per-port bitwidth macros in `config.vh`
- rename localparams in `moduleA` and `moduleB` to follow the PORTNAME_BITWIDTH convention

## Testing
- `iverilog -tnull moduleA.v moduleB.v`

------
https://chatgpt.com/codex/tasks/task_e_687fa36a98008320b2f82a18322c793b